### PR TITLE
fix: please cargo clippy

### DIFF
--- a/src/response/response_builder.rs
+++ b/src/response/response_builder.rs
@@ -20,6 +20,12 @@ pub struct ResponseBuilder {
     extensions: Option<Extensions>,
 }
 
+impl Default for ResponseBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[pymethods]
 impl ResponseBuilder {
     #[new]


### PR DESCRIPTION
I discovered accidentaly while working on adding basedpyright that `make lint` errors out:
```
❯ make lint
uv run ruff check .
All checks passed!
uv run ruff format --check .
96 files already formatted
cargo fmt --check
cargo clippy -- -D warnings
   Compiling pyo3-build-config v0.27.2
   Compiling pyo3-ffi v0.27.2
   Compiling pyo3-macros-backend v0.27.2
   Compiling pyo3 v0.27.2
   Compiling pyreqwest v0.9.0 (/home/lotso/code/pyreqwest)
   Compiling pyo3-macros v0.27.2
    Checking pyo3-bytes v0.5.0
    Checking pythonize v0.27.0
error: you should consider adding a `Default` implementation for `ResponseBuilder`
   --> src/response/response_builder.rs:142:5
    |
142 | /     pub fn new() -> Self {
143 | |         let (head, _) = http::response::Response::new(()).into_parts();
144 | |         Self {
145 | |             head: Some(head),
...   |
149 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#new_without_default
    = note: `-D clippy::new-without-default` implied by `-D clippy::all`
    = help: to override `-D clippy::all` add `#[allow(clippy::new_without_default)]`
help: try adding this
    |
141 + impl Default for ResponseBuilder {
142 +     fn default() -> Self {
143 +         Self::new()
144 +     }
145 + }
    |

error: could not compile `pyreqwest` (lib) due to 1 previous error
make: *** [Makefile:18: lint] Error 101
```

I followed the compiler suggestion which seems to solve it, but being quite new to rust I'm not 100% sure.
Side note, doesnt that error suggest there may be no CI checks for this ?