### PR TITLE
Tighten collections.abc import

### DIFF
--- a/src/internal/module_utils.rs
+++ b/src/internal/module_utils.rs
@@ -19,8 +19,7 @@ pub fn register_collections_abc<T: PyTypeInfo>(py: Python, base: &str) -> PyResu
         return Ok(()); // :NOCOV
     }
 
-    py.import("collections")?
-        .getattr("abc")?
+    py.import("collections.abc")?
         .getattr(base)?
         .call_method1(intern!(py, "register"), (PyType::new::<T>(py),))
         .map(|_| ())


### PR DESCRIPTION
I went down an odd rabbit hole and looked into packaging pyreqwest into deb to be installed by apt (just for my own personal use/curiosity) and ran into an odd importing issue.

My initial attempts at using the library after installing led to an AttributeError from collections
```python
> python3 -c "import pyreqwest; print(pyreqwest.__file__)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/pyreqwest/__init__.py", line 3, in <module>
    from ._pyreqwest import __version__, _start_time_ns  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'abc'
```

After narrowing down the import on the Rust side, changing to the combined import and rebuilding, I was able to get everything working. I will be the first to admit that I do not know Rust well, so this change may have side effects that I have not tested. However, I have yet to encounter any in my own testing.

I have also tested this in a uv script environment targeting my local version with the change and using a different Python version, and it compiled and ran without issue as well, so I do not believe it is a breaking change from my testing.