### PR TITLE
Add WSGITestMiddleware for SyncClient support

### DIFF
--- a/python/pyreqwest/middleware/wsgi/__init__.py
+++ b/python/pyreqwest/middleware/wsgi/__init__.py
@@ -1,0 +1,5 @@
+"""WSGI middleware."""
+
+from .wsgi import WSGITestMiddleware
+
+__all__ = ["WSGITestMiddleware"]

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -49,7 +49,7 @@ class WSGITestMiddleware:
                         # Re-raise original exception if headers have already been sent
                         raise exc_info[1].with_traceback(exc_info[2])
                 finally:
-                    exc_info = None
+                    exc_info = None  # avoid dangling circular ref
 
             status_code = int(status.split(" ", 1)[0])
             response_builder.status(status_code)

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -36,13 +36,14 @@ class WSGITestMiddleware:
         environ = self._request_to_wsgi_environ(request)
 
         response_builder = ResponseBuilder()
-        headers_set: list[Any] = []
+        headers_set: bool = False
 
         def start_response(
             status: str,
             response_headers: list[tuple[str, str]],
             exc_info: Any | None = None,
         ) -> Callable[[bytes], None]:
+            nonlocal headers_set
             if exc_info:
                 try:
                     if headers_set:
@@ -54,7 +55,7 @@ class WSGITestMiddleware:
             status_code = int(status.split(" ", 1)[0])
             response_builder.status(status_code)
             response_builder.headers(response_headers)
-            headers_set.append(True)
+            headers_set = True
 
             def write(data: bytes) -> None:
                 raise NotImplementedError(

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -9,7 +9,8 @@ from pyreqwest.middleware import SyncNext
 from pyreqwest.request import Request
 from pyreqwest.response import ResponseBuilder, SyncResponse
 
-WSGIApp = Callable[[dict[str, Any], Callable[[str, list[tuple[str, str]], Any | None], None]], Iterable[bytes]]
+StartResponse = Callable[[str, list[tuple[str, str]], Any | None], Callable[[bytes], None]]
+WSGIApp = Callable[[dict[str, Any], StartResponse], Iterable[bytes]]
 
 
 class WSGITestMiddleware:
@@ -95,7 +96,7 @@ class WSGITestMiddleware:
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": url.scheme or "http",
             "wsgi.input": self._wsgi_input(request),
-            "wsgi.errors": io.BytesIO(),
+            "wsgi.errors": io.StringIO(),
             "wsgi.multithread": False,
             "wsgi.multiprocess": False,
             "wsgi.run_once": False,

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -56,7 +56,9 @@ class WSGITestMiddleware:
             headers_set.append(True)
 
             def write(data: bytes) -> None:
-                raise NotImplementedError("WSGI write callable is not supported by this test client. Yield bytes from the app instead.")
+                raise NotImplementedError(
+                    "WSGI write callable is not supported by this test client. Yield bytes from the app instead."
+                )
 
             return write
 
@@ -68,6 +70,9 @@ class WSGITestMiddleware:
             first_chunk = next(iterator)
         except StopIteration:
             pass
+
+        if not headers_set:
+            raise RuntimeError("WSGI app returned without calling start_response")
 
         def stream_wrapper() -> Iterable[bytes]:
             if first_chunk is not None:

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -1,0 +1,129 @@
+"""WSGI middleware."""
+
+import io
+from collections.abc import Callable, Iterable
+from typing import Any
+from urllib.parse import unquote
+
+from pyreqwest.middleware import SyncNext
+from pyreqwest.request import Request
+from pyreqwest.response import ResponseBuilder, SyncResponse
+
+WSGIApp = Callable[[dict[str, Any], Callable[[str, list[tuple[str, str]], Any | None], None]], Iterable[bytes]]
+
+
+class WSGITestMiddleware:
+    """Test client that routes requests into a WSGI application."""
+
+    def __init__(
+        self,
+        app: WSGIApp,
+        *,
+        scope_update: Callable[[dict[str, Any], Request], None] | None = None,
+    ) -> None:
+        """Initialize the WSGI test client.
+
+        Args:
+            app: WSGI application callable
+            scope_update: Optional callable to modify the WSGI environ per request
+        """
+        self._app = app
+        self._scope_update = scope_update
+
+    def __call__(self, request: Request, _next_handler: SyncNext) -> SyncResponse:
+        """WSGI middleware handler."""
+        environ = self._request_to_wsgi_environ(request)
+
+        response_builder = ResponseBuilder()
+        headers_set: list[Any] = []
+
+        def start_response(
+            status: str,
+            response_headers: list[tuple[str, str]],
+            exc_info: Any | None = None,
+        ) -> Callable[[bytes], None]:
+            if exc_info:
+                try:
+                    if headers_set:
+                        # Re-raise original exception if headers have already been sent
+                        raise exc_info[1].with_traceback(exc_info[2])
+                finally:
+                    exc_info = None
+
+            status_code = int(status.split(" ", 1)[0])
+            response_builder.status(status_code)
+            response_builder.headers(response_headers)
+            headers_set.append(True)
+
+            def write(data: bytes) -> None:
+                raise NotImplementedError("WSGI write callable is not supported by this test client. Yield bytes from the app instead.")
+
+            return write
+
+        body_iterable = self._app(environ, start_response)
+
+        iterator = iter(body_iterable)
+        first_chunk = None
+        try:
+            first_chunk = next(iterator)
+        except StopIteration:
+            pass
+
+        def stream_wrapper() -> Iterable[bytes]:
+            if first_chunk is not None:
+                yield first_chunk
+            yield from iterator
+
+        response_builder.body_stream(stream_wrapper())
+        return response_builder.build_sync()
+
+    def _request_to_wsgi_environ(self, request: Request) -> dict[str, Any]:
+        url = request.url
+        environ: dict[str, Any] = {
+            "REQUEST_METHOD": request.method.upper(),
+            "SCRIPT_NAME": "",
+            "PATH_INFO": unquote(url.path),
+            "QUERY_STRING": url.query_string or "",
+            "SERVER_NAME": url.host_str or "localhost",
+            "SERVER_PORT": str(url.port or (443 if url.scheme == "https" else 80)),
+            "SERVER_PROTOCOL": "HTTP/1.1",
+            "wsgi.version": (1, 0),
+            "wsgi.url_scheme": url.scheme or "http",
+            "wsgi.input": self._wsgi_input(request),
+            "wsgi.errors": io.BytesIO(),
+            "wsgi.multithread": False,
+            "wsgi.multiprocess": False,
+            "wsgi.run_once": False,
+        }
+
+        for name, value in request.headers.items():
+            key = f"HTTP_{name.upper().replace('-', '_')}"
+            if key not in environ:
+                environ[key] = value
+            else:
+                environ[key] = f"{environ[key]},{value}"
+
+        if "HTTP_CONTENT_TYPE" in environ:
+            environ["CONTENT_TYPE"] = environ.pop("HTTP_CONTENT_TYPE")
+        if "HTTP_CONTENT_LENGTH" in environ:
+            environ["CONTENT_LENGTH"] = environ.pop("HTTP_CONTENT_LENGTH")
+
+        if self._scope_update is not None:
+            self._scope_update(environ, request)
+
+        return environ
+
+    def _wsgi_input(self, request: Request) -> io.BytesIO:
+        body = request.body
+        if body is None:
+            return io.BytesIO(b"")
+
+        if (bytes_body := body.copy_bytes()) is not None:
+            return io.BytesIO(bytes_body.to_bytes())
+
+        stream = body.get_stream()
+        if stream is not None:
+            chunks = list(stream)
+            return io.BytesIO(b"".join(chunks))
+
+        return io.BytesIO(b"")

--- a/python/pyreqwest/middleware/wsgi/wsgi.py
+++ b/python/pyreqwest/middleware/wsgi/wsgi.py
@@ -1,13 +1,17 @@
 """WSGI middleware."""
 
+import contextlib
 import io
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import unquote
 
 from pyreqwest.middleware import SyncNext
 from pyreqwest.request import Request
 from pyreqwest.response import ResponseBuilder, SyncResponse
+
+if TYPE_CHECKING:
+    from pyreqwest.types import SyncStream
 
 StartResponse = Callable[[str, list[tuple[str, str]], Any | None], Callable[[bytes], None]]
 WSGIApp = Callable[[dict[str, Any], StartResponse], Iterable[bytes]]
@@ -58,9 +62,8 @@ class WSGITestMiddleware:
             headers_set = True
 
             def write(data: bytes) -> None:
-                raise NotImplementedError(
-                    "WSGI write callable is not supported by this test client. Yield bytes from the app instead."
-                )
+                msg = "WSGI write callable is not supported by this test client. Yield bytes from the app instead."
+                raise NotImplementedError(msg)
 
             return write
 
@@ -68,13 +71,12 @@ class WSGITestMiddleware:
 
         iterator = iter(body_iterable)
         first_chunk = None
-        try:
+        with contextlib.suppress(StopIteration):
             first_chunk = next(iterator)
-        except StopIteration:
-            pass
 
         if not headers_set:
-            raise RuntimeError("WSGI app returned without calling start_response")
+            msg = "WSGI app returned without calling start_response"
+            raise RuntimeError(msg)
 
         def stream_wrapper() -> Iterable[bytes]:
             if first_chunk is not None:
@@ -130,7 +132,7 @@ class WSGITestMiddleware:
 
         stream = body.get_stream()
         if stream is not None:
-            chunks = list(stream)
-            return io.BytesIO(b"".join(chunks))
+            sync_stream: SyncStream = stream  # type: ignore[assignment]  # WSGI is always sync
+            return io.BytesIO(b"".join(cast("Iterable[bytes]", sync_stream)))
 
         return io.BytesIO(b"")

--- a/tests/test_middleware_wsgi_client.py
+++ b/tests/test_middleware_wsgi_client.py
@@ -32,7 +32,6 @@ def simple_wsgi_app(
         query_string = environ.get("QUERY_STRING", "")
         body = environ["wsgi.input"].read().decode()
 
-
         resp = {"method": method}
         if headers:
             # Sort headers for stable tests

--- a/tests/test_middleware_wsgi_client.py
+++ b/tests/test_middleware_wsgi_client.py
@@ -1,0 +1,153 @@
+from collections.abc import Callable, Generator
+from typing import Any
+
+import pytest
+from pyreqwest.client import SyncClient, SyncClientBuilder
+from pyreqwest.middleware.wsgi import WSGITestMiddleware
+from pyreqwest.request import Request
+
+
+def simple_wsgi_app(environ: dict[str, Any], start_response: Callable[[str, list[tuple[str, str]], Any | None], None]) -> Generator[bytes, None, None]:
+    path = environ.get("PATH_INFO", "/")
+    
+    if path == "/":
+        start_response("200 OK", [("Content-Type", "application/json")])
+        yield b'{"message": "Hello World"}'
+    elif path.startswith("/param/"):
+        param = path.split("/")[-1]
+        start_response("200 OK", [("Content-Type", "application/json")])
+        yield f'{{"param": "{param}"}}'.encode()
+    elif path == "/echo":
+        method = environ["REQUEST_METHOD"]
+        headers = []
+        for k, v in environ.items():
+            if k.startswith("HTTP_"):
+                headers.append((k[5:].lower().replace("_", "-"), v))
+            elif k in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+                headers.append((k.lower().replace("_", "-"), v))
+        
+        query_string = environ.get("QUERY_STRING", "")
+        body = environ["wsgi.input"].read().decode()
+        
+        import json
+        resp = {"method": method}
+        if headers:
+            # Sort headers for stable tests
+            resp["headers"] = sorted(headers)
+        if query_string:
+            resp["query_string"] = query_string
+        if body:
+            resp["body"] = body
+            
+        start_response("200 OK", [("Content-Type", "application/json")])
+        yield json.dumps(resp).encode()
+    elif path == "/error":
+        start_response("404 Not Found", [("Content-Type", "application/json")])
+        yield b'{"detail": "Not found"}'
+    elif path == "/stream":
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        yield b"chunk_0_"
+        yield b"chunk_1_"
+        yield b"chunk_2_"
+    else:
+        start_response("404 Not Found", [("Content-Type", "text/plain")])
+        yield b"Not found"
+
+
+@pytest.fixture
+def wsgi_client() -> Generator[SyncClient, None, None]:
+    middleware = WSGITestMiddleware(simple_wsgi_app)
+    with SyncClientBuilder().base_url("http://localhost").with_middleware(middleware).build() as client:
+        yield client
+
+
+def test_get_root(wsgi_client: SyncClient):
+    response = wsgi_client.get("/").build().send()
+    assert response.status == 200
+    data = response.json()
+    assert data == {"message": "Hello World"}
+
+
+def test_get_with_path_params(wsgi_client: SyncClient):
+    response = wsgi_client.get("/param/42").build().send()
+    assert response.status == 200
+    data = response.json()
+    assert data == {"param": "42"}
+
+
+def test_post_json(wsgi_client: SyncClient):
+    request_data = {"name": "John Doe", "email": "john@example.com"}
+    response = wsgi_client.post("/echo").body_json(request_data).build().send()
+    assert response.status == 200
+    data = response.json()
+    assert data["method"] == "POST"
+    assert "headers" in data
+    import json
+    assert json.loads(data["body"]) == request_data
+
+
+def test_put_json(wsgi_client: SyncClient):
+    response = wsgi_client.put("/echo").body_json({"name": "Jane Doe"}).build().send()
+    assert response.status == 200
+    data = response.json()
+    assert data["method"] == "PUT"
+    assert "headers" in data
+    import json
+    assert json.loads(data["body"]) == {"name": "Jane Doe"}
+
+
+def test_headers(wsgi_client: SyncClient):
+    response = (
+        wsgi_client.get("/echo")
+        .header("X-Header-1", "value1")
+        .header("X-Header-2", "value2")
+        .header("X-Header-2", "value3")
+        .build()
+        .send()
+    )
+    assert response.status == 200
+    headers = response.json()["headers"]
+    assert ["x-header-1", "value1"] in headers
+    # WSGI concatenates multiple headers of the same name with commas
+    assert ["x-header-2", "value2,value3"] in headers
+
+
+def test_query_parameters(wsgi_client: SyncClient):
+    response = wsgi_client.get("/echo").query([("k1", "v1"), ("k2", "v2"), ("k1", "v3")]).build().send()
+    assert response.status == 200
+    assert response.json()["query_string"] == "k1=v1&k2=v2&k1=v3"
+
+
+def test_error_response(wsgi_client: SyncClient):
+    response = wsgi_client.get("/error").build().send()
+    assert response.status == 404
+    data = response.json()
+    assert data["detail"] == "Not found"
+
+
+def test_streaming(wsgi_client: SyncClient):
+    with wsgi_client.post("/stream").build_streamed() as response:
+        assert response.status == 200
+
+        assert response.body_reader.read_chunk() == b"chunk_0_"
+        assert response.body_reader.read_chunk() == b"chunk_1_"
+        assert response.body_reader.read_chunk() == b"chunk_2_"
+        assert response.body_reader.read_chunk() is None
+
+
+def test_scope_override():
+    def scope_update(environ: dict[str, Any], request: Request) -> None:
+        assert request.extensions["test"] == "something"
+        assert environ.get("HTTP_X_TEST_HEADER") == "test-value"
+        environ["HTTP_X_ADDED_HEADER"] = "added-value"
+
+    middleware = WSGITestMiddleware(simple_wsgi_app, scope_update=scope_update)
+    with SyncClientBuilder().base_url("http://localhost").with_middleware(middleware).build() as client:
+        req = client.get("/echo").header("X-Test-Header", "test-value").build()
+        req.extensions["test"] = "something"
+        resp = req.send()
+        assert resp.status == 200
+        
+        headers = resp.json()["headers"]
+        assert ["x-test-header", "test-value"] in headers
+        assert ["x-added-header", "added-value"] in headers

--- a/tests/test_middleware_wsgi_client.py
+++ b/tests/test_middleware_wsgi_client.py
@@ -9,7 +9,7 @@ from pyreqwest.request import Request
 
 
 def simple_wsgi_app(
-    environ: dict[str, Any], start_response: Callable[[str, list[tuple[str, str]], Any | None], None]
+    environ: dict[str, Any], start_response: Callable[..., Callable[[bytes], None]]
 ) -> Generator[bytes, None, None]:
     path = environ.get("PATH_INFO", "/")
 

--- a/tests/test_middleware_wsgi_client.py
+++ b/tests/test_middleware_wsgi_client.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Callable, Generator
 from typing import Any
 
@@ -7,9 +8,11 @@ from pyreqwest.middleware.wsgi import WSGITestMiddleware
 from pyreqwest.request import Request
 
 
-def simple_wsgi_app(environ: dict[str, Any], start_response: Callable[[str, list[tuple[str, str]], Any | None], None]) -> Generator[bytes, None, None]:
+def simple_wsgi_app(
+    environ: dict[str, Any], start_response: Callable[[str, list[tuple[str, str]], Any | None], None]
+) -> Generator[bytes, None, None]:
     path = environ.get("PATH_INFO", "/")
-    
+
     if path == "/":
         start_response("200 OK", [("Content-Type", "application/json")])
         yield b'{"message": "Hello World"}'
@@ -25,11 +28,11 @@ def simple_wsgi_app(environ: dict[str, Any], start_response: Callable[[str, list
                 headers.append((k[5:].lower().replace("_", "-"), v))
             elif k in ("CONTENT_TYPE", "CONTENT_LENGTH"):
                 headers.append((k.lower().replace("_", "-"), v))
-        
+
         query_string = environ.get("QUERY_STRING", "")
         body = environ["wsgi.input"].read().decode()
-        
-        import json
+
+
         resp = {"method": method}
         if headers:
             # Sort headers for stable tests
@@ -38,7 +41,7 @@ def simple_wsgi_app(environ: dict[str, Any], start_response: Callable[[str, list
             resp["query_string"] = query_string
         if body:
             resp["body"] = body
-            
+
         start_response("200 OK", [("Content-Type", "application/json")])
         yield json.dumps(resp).encode()
     elif path == "/error":
@@ -82,7 +85,7 @@ def test_post_json(wsgi_client: SyncClient):
     data = response.json()
     assert data["method"] == "POST"
     assert "headers" in data
-    import json
+
     assert json.loads(data["body"]) == request_data
 
 
@@ -92,7 +95,7 @@ def test_put_json(wsgi_client: SyncClient):
     data = response.json()
     assert data["method"] == "PUT"
     assert "headers" in data
-    import json
+
     assert json.loads(data["body"]) == {"name": "Jane Doe"}
 
 
@@ -147,7 +150,7 @@ def test_scope_override():
         req.extensions["test"] = "something"
         resp = req.send()
         assert resp.status == 200
-        
+
         headers = resp.json()["headers"]
         assert ["x-test-header", "test-value"] in headers
         assert ["x-added-header", "added-value"] in headers


### PR DESCRIPTION
Closes #37.

This PR adds `WSGITestMiddleware` to complement the existing ASGI test support. This allows users to test synchronous WSGI applications (like Flask or Django) directly with `SyncClientBuilder` without needing to spin up a real server.

### Changes:
- Added `WSGITestMiddleware` in `pyreqwest.middleware.wsgi`.
- Implemented standard WSGI `environ` translation from `pyreqwest` requests.
- Added a `stream_wrapper` to ensure `start_response` is called before the response is built, avoiding borrow errors during the sync build process.
- Added tests in `tests/test_middleware_wsgi_client.py` covering GET/POST, headers, query params, and streaming.
