### PR TITLE
Do not use mimalloc on macOS (prevent pyarrow memory pool corruption)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,14 @@ pin-project = "=1.1.13"
 time = "=0.3.54"
 regex = "=1.13.1"
 log = "=0.4.33"
-mimalloc = { version = "0.1.52", default-features = false, features = ["local_dynamic_tls"], optional = true }
 base64 = "=0.22.1"
+
+# Not on macOS. mimalloc finds its per-thread heap through hardcoded pthread TSD slots there, so a
+# second static copy in the same process collides with the first — and pyarrow ships one, statically
+# linked, as its default memory pool on macOS. Loading this module after pyarrow then corrupts every
+# buffer pyarrow allocates afterwards. Other platforms use ordinary per-DSO TLS and are unaffected.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+mimalloc = { version = "0.1.52", default-features = false, features = ["local_dynamic_tls"], optional = true }
 
 [build-dependencies]
 pyo3-build-config = "=0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ regex = "=1.13.1"
 log = "=0.4.33"
 base64 = "=0.22.1"
 
+# TODO: remove target_os after https://github.com/purpleprotocol/mimalloc_rust/pull/169
 # Not on macOS. mimalloc finds its per-thread heap through hardcoded pthread TSD slots there, so a
 # second static copy in the same process collides with the first — and pyarrow ships one, statically
 # linked, as its default memory pool on macOS. Loading this module after pyarrow then corrupts every

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ use crate::internal::module_utils::{register_collections_abc, register_submodule
 use crate::internal::types::Method;
 use crate::request::{OneOffRequestBuilder, SyncOneOffRequestBuilder};
 
-#[cfg(feature = "mimalloc")]
+// See the target-gated mimalloc dependency in Cargo.toml: on macOS a second static mimalloc copy
+// collides with pyarrow's over mimalloc's hardcoded pthread TSD slots, so the dependency is not
+// compiled there and enabling the feature is a no-op.
+#[cfg(all(feature = "mimalloc", not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,7 @@ use crate::internal::module_utils::{register_collections_abc, register_submodule
 use crate::internal::types::Method;
 use crate::request::{OneOffRequestBuilder, SyncOneOffRequestBuilder};
 
-// See the target-gated mimalloc dependency in Cargo.toml: on macOS a second static mimalloc copy
-// collides with pyarrow's over mimalloc's hardcoded pthread TSD slots, so the dependency is not
-// compiled there and enabling the feature is a no-op.
+// See the target-gated mimalloc dependency in Cargo.toml
 #[cfg(all(feature = "mimalloc", not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
Hope you don't mind an AI-assisted PR, since the change is small and focused on a specific bug.

## The problem

pyarrow statically links its own copy of mimalloc and uses it as the default memory pool on macOS. pyreqwest links a second static copy as its `#[global_allocator]`. On macOS mimalloc locates its per-thread heap through hardcoded pthread TSD slots, so the two copies collide: whichever initializes last claims the slot, and the other then reads a foreign heap as its own.

The result is silent memory corruption in pyarrow. No network call, no pyreqwest API use — the import is enough:

```python
import pyarrow as pa
import pyreqwest.exceptions
pa.table({"sales": [10, 20]}).to_pydict()
# {'sales': [0, 4527375348]}
```

Tables allocated *before* the import survive; everything allocated after is garbage. Order matters — `import pyreqwest` before `import pyarrow` is fine, which is what makes this so easy to hit by accident and so confusing to debug.

Verified on macOS arm64, Python 3.12 and 3.13, pyarrow 25.0.0, pyreqwest 0.12.2 (published wheel), in a clean venv containing only those two packages.

Two things confirm the diagnosis rather than merely correlate with it:

- `ARROW_DEFAULT_MEMORY_POOL=system` makes it go away — removing pyarrow's mimalloc copy resolves it.
- Building pyreqwest 0.12.2 **without** `--features mimalloc` makes it go away. I built both variants from the v0.12.2 tag to check.

It is specifically *two mimallocs*, not "a Rust extension loaded after pyarrow": polars is a Rust extension that loads after pyarrow without trouble, and it has no mimalloc in it — it uses the system allocator on macOS arm64.

This is arguably upstream mimalloc's to make impossible (there is a "fix for multiple mimalloc instances in one executable" as far back as v1.6.2, and the macOS TLS slot numbers have churned 108/109 → 126/127 → back to 108/109 in 3.4.3), but that has been a long-running battle and pyarrow's macOS default is not going to move.

## The change

Gate the dependency on the target, not just the `#[global_allocator]` item, so the second copy is never linked into a macOS build at all. Everything else keeps mimalloc exactly as today — on other platforms mimalloc uses ordinary per-DSO TLS, where two copies do not share state.

`cargo tree --features mimalloc` on macOS resolves without mimalloc; `--target x86_64-unknown-linux-gnu --features mimalloc` still pulls in `mimalloc v0.1.52`. CI can keep passing `--features mimalloc` for macOS targets unchanged — it simply becomes a no-op there.

I have not verified the Linux side empirically (no Linux box here), only that the dependency still resolves for that target. If pyarrow turns out to default to mimalloc rather than jemalloc on some Linux build, the same gate would be wanted there too.

## What it costs

I benchmarked both builds with this repo's own harness — `tests/bench/latency.py`, `pyreqwest_st`, granian + TLS echo server — alternating variants across two passes on macOS arm64 / Python 3.12, to keep thermal drift from favoring either side.

| Body | Concurrency | with mimalloc | without | cost |
|---|---|---|---|---|
| 10 KB | 2 | 10.70 ms | 11.03 ms | +3.0% |
| 10 KB | 100 | 7.56 ms | 7.74 ms | +2.4% |
| 10 KB | 10 | 8.47 ms | 8.66 ms | +2.2% |
| 100 KB | 2 | 23.58 ms | 24.00 ms | +1.7% |
| 100 KB | 100 | 14.32 ms | 14.53 ms | +1.5% |
| 1 MB | 2 | 132.7 ms | 134.3 ms | +1.2% |
| 1 MB | 10 | 88.8 ms | 89.8 ms | +1.0% |
| 1 MB | 100 | 72.3 ms | 72.6 ms | +0.4% |
| 2 MB | 100 | 232.9 ms | 234.5 ms | +0.7% |
| 2 MB | 10 | 229.5 ms | 230.1 ms | +0.2% |
| 2 MB | 2 | 305.3 ms | 305.2 ms | −0.1% |

So roughly **2–3% on small responses, ~1% at 1 MB, ~0% at 2 MB**, on macOS only. The gradient is monotone in body size, which is what you would expect if the win is per-allocation overhead amortized against body copying. One cell (100 KB / concurrency 10) produced a 19.6 ms outlier against its own 16.9 ms twin in the other pass; I have left it out rather than let noise claim a regression. mimalloc won 10 of the remaining 11 cells. Wheel size differs by 52 KB.

That is a real cost and it is your call whether it is worth paying. Alternatives if you would rather not: publish a separate no-mimalloc wheel variant for macOS, or document the incompatibility so people can build from source without the feature. Happy to rework this in either direction.

## Checks

- `pytest` — 734 passed, 62 snapshots
- `cargo fmt --check`, `cargo clippy --features mimalloc -- -D warnings` — clean
- macOS release wheel built with `--features mimalloc`: no mimalloc in the binary, pyarrow uninjured, requests work

## Context

Found while adding a pyreqwest transport to [typicall](https://github.com/alexeyshockov/typicall), which also offers an Arrow/dataframe converter — so the two extras land in one process routinely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
